### PR TITLE
Completly rewritten extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is Fork of [Kdyby/Monolog](https://github.com/kdyby/monolog), licensed unde
 Installation
 ------------
 
-The best way to install MG/Monolog is using [Composer](http://getcomposer.org/):
+The best way to install Mallgroup/Monolog is using [Composer](http://getcomposer.org/):
 
 ```sh
 $ composer require mallgroup/monolog

--- a/composer.json
+++ b/composer.json
@@ -23,29 +23,33 @@
 	],
 	"require": {
 		"php": ">=7.4 <8.1",
-		"nette/di": "^2.4.17 || ^3.0",
-		"nette/utils": "^2.5.7 || ^3.0",
+		"nette/di": "^3.0",
+		"nette/utils": "^3.0",
 		"monolog/monolog": "^2.2",
-		"tracy/tracy": "^2.6.8"
+		"nette/schema": "^1.2"
 	},
 	"require-dev": {
-		"nette/application": "^2.4.17 || ^3.0.7",
-		"nette/bootstrap": "^2.4.6 || ^3.0",
-		"nette/caching": "^2.5.9 || ^3.0",
-		"nette/http": "^2.4.12 || ^3.0",
+		"nette/application": "^3.0.7",
+		"nette/bootstrap": "^3.0",
+		"nette/caching": "^3.0",
+		"nette/http": "^3.0",
 		"nette/tester": "^2.4",
 		"psr/log": "^1.1",
-		"phpstan/phpstan": "^0.12.80",
-		"php-parallel-lint/php-parallel-lint": "^1.2"
+		"phpstan/phpstan-nette": "^0.12",
+		"php-parallel-lint/php-parallel-lint": "^1.2",
+		"tracy/tracy": "2.6"
+	},
+	"suggest": {
+		"tracy/tracy": "To set tracyHook and get Tracy blueScreen on exceptions"
 	},
 	"minimum-stability": "stable",
 	"support": {
 		"email": "radovan.kepak@mallgroup.com",
-		"issues": "https://github.com/MG/monolog/issues"
+		"issues": "https://github.com/mallgroup/monolog/issues"
 	},
 	"autoload": {
 		"psr-4": {
-			"MG\\Monolog\\": "src/"
+			"Mallgroup\\Monolog\\": "src/"
 		}
 	},
 	"autoload-dev": {
@@ -58,7 +62,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0-dev"
+			"dev-master": "2.0-dev"
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	],
 	"require": {
 		"php": ">=7.4 <8.1",
-		"nette/di": "^3.0",
+		"nette/di": "^3.0.5",
 		"nette/utils": "^3.0",
 		"monolog/monolog": "^2.2",
 		"nette/schema": "^1.2"
@@ -35,7 +35,7 @@
 		"nette/http": "^3.0",
 		"nette/tester": "^2.4",
 		"psr/log": "^1.1",
-		"phpstan/phpstan-nette": "^0.12",
+		"phpstan/phpstan-nette": "^0.12.15",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"tracy/tracy": "2.6"
 	},

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -7,7 +7,7 @@ Integration of [Monolog](https://github.com/Seldaek/monolog) into Nette Framewor
 Installation
 ------------
 
-The best way to install MG/Monolog is using [Composer](http://getcomposer.org/):
+The best way to install Mallgroup/Monolog is using [Composer](http://getcomposer.org/):
 
 ```sh
 $ composer require mallgroup/monolog

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -17,7 +17,7 @@ and enable it in `config.neon`
 
 ```yml
 extensions:
-	monolog: MG\Monolog\DI\MonologExtension
+	monolog: Mallgroup\Monolog\DI\MonologExtension
 ```
 
 
@@ -45,7 +45,7 @@ You can of course turn off the registration into Tracy
 
 ```yml
 monolog:
-	hookToTracy: off
+	tracyHook: off
 ```
 
 but then you have to handle the messages yourself and you're giving up the power of Monolog.
@@ -90,7 +90,7 @@ Processors are special type of class, that has to implement one method only - `_
 They're called for every message, that is sent to Monolog so they can change it's contents.
 When you're adding processor programatically in your application, you can also use closures.
 
-MG\Monolog always registers it's custom `PriorityProcessor`, which has two tasks
+Mallgroup\Monolog always registers it's custom `PriorityProcessor`, which has two tasks
 
 - when message `context` contains `channel` name, change the real `channel` to that name and unset the value from `context`
 - or, when the `context` has `priority` defined and the priority is standard name of record level (info, warning, error, ...) change the `channel` name to that
@@ -142,10 +142,10 @@ class EmailQueue
 Let's change the signature a bit, so the autocompletion starts working as expected
 
 ```php
-public function __construct(\Nette\Mail\IMailer $mailer, \MG\Monolog\Logger $logger)
+public function __construct(\Nette\Mail\IMailer $mailer, \Mallgroup\Monolog\Logger $logger)
 ```
 
-The custom logger in MG\Monolog only adds one new method `->channel($name)`, which is a factory for custom Logger with custom channel, that does nothing but proxy the messages to it's parent.
+The custom logger in Mallgroup\Monolog only adds one new method `->channel($name)`, which is a factory for custom Logger with custom channel, that does nothing but proxy the messages to it's parent.
 
 If we now use the factory instead of simply assigning the value
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,9 @@ parameters:
 
 	paths:
 		- src
+
+	stubFiles:
+		- stubs/DI/CompilerExtension.stub
+
+includes:
+	- vendor/phpstan/phpstan-nette/extension.neon

--- a/src/CustomChannel.php
+++ b/src/CustomChannel.php
@@ -7,9 +7,9 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog;
+namespace Mallgroup\Monolog;
 
-use MG\Monolog\Logger as CustomLogger;
+use Mallgroup\Monolog\Logger as CustomLogger;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Logger as MonologLogger;
 use Nette\SmartObject;

--- a/src/DI/MonologExtension.php
+++ b/src/DI/MonologExtension.php
@@ -27,7 +27,6 @@ use Nette\PhpGenerator\Closure;
 use Nette\PhpGenerator\PhpLiteral;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
-use Nette\SmartObject;
 use Nette\Utils\Strings;
 use Psr\Log\LoggerAwareInterface;
 use RuntimeException;
@@ -39,12 +38,6 @@ use Tracy\ILogger;
  */
 class MonologExtension extends CompilerExtension
 {
-	use SmartObject;
-
-	public const TAG_HANDLER = 'monolog.handler';
-	public const TAG_PROCESSOR = 'monolog.processor';
-	public const TAG_PRIORITY = 'monolog.priority';
-
 	/** @var PriorityDefinition[] */
 	private array $handlers = [];
 
@@ -54,7 +47,7 @@ class MonologExtension extends CompilerExtension
 	public static function register(Configurator $configurator): void
 	{
 		$configurator->onCompile[] = static function ($config, Compiler $compiler) {
-			$compiler->addExtension('monolog', new MonologExtension());
+			$compiler->addExtension('monolog', new MonologExtension);
 		};
 	}
 
@@ -97,7 +90,6 @@ class MonologExtension extends CompilerExtension
 
 	protected function loadHandlers(): void
 	{
-		$builder = $this->getContainerBuilder();
 		foreach ($this->config->handlers as $name => $implementation) {
 			$this->handlers[] = new PriorityDefinition(
 				$this->getDefinition(
@@ -111,10 +103,9 @@ class MonologExtension extends CompilerExtension
 
 	protected function loadProcessors(): void
 	{
-		$builder = $this->getContainerBuilder();
 		if ($this->config->usePriorityProcessor === true) {
 			$this->processors[] = new PriorityDefinition(
-				$builder
+				$this->getContainerBuilder()
 					->addDefinition($this->prefix('processor.priorityProcessor'))
 					->setFactory(PriorityProcessor::class),
 				20
@@ -153,7 +144,7 @@ class MonologExtension extends CompilerExtension
 
 			// Inline definition
 			return $builder
-				->addDefinition($name, (new ServiceDefinition())->setType($definition))
+				->addDefinition($name, (new ServiceDefinition)->setType($definition))
 				->setAutowired(false);
 		}
 

--- a/src/DI/PriorityDefinition.php
+++ b/src/DI/PriorityDefinition.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Mallgroup\Monolog\DI;
+
+
+use Nette\DI\Definitions\Definition;
+
+class PriorityDefinition
+{
+	/** @var Definition|string */
+	protected $definition;
+	protected int $priority;
+
+	/**
+	 * PriorityDefinition constructor.
+	 * @param Definition|string $definition
+	 * @param int $priority
+	 */
+	public function __construct($definition, int $priority = 0) {
+		$this->definition = $definition;
+		$this->priority = $priority;
+	}
+
+	public function getPriority(): int {
+		return $this->priority;
+	}
+
+	/**
+	 * @return Definition|string
+	 */
+	public function getDefinition() {
+		return $this->definition;
+	}
+}

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -8,7 +8,7 @@
  * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
  */
 
-namespace MG\Monolog\Exception;
+namespace Mallgroup\Monolog\Exception;
 
 interface Exception
 {

--- a/src/Exception/NotSupportedException.php
+++ b/src/Exception/NotSupportedException.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Exception;
+namespace Mallgroup\Monolog\Exception;
 
 class NotSupportedException extends \LogicException implements Exception
 {

--- a/src/Handler/FallbackNetteHandler.php
+++ b/src/Handler/FallbackNetteHandler.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Handler;
+namespace Mallgroup\Monolog\Handler;
 
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger as MonologLogger;

--- a/src/Handler/NewRelicHandler.php
+++ b/src/Handler/NewRelicHandler.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Handler;
+namespace Mallgroup\Monolog\Handler;
 
 use Monolog\Handler\MissingExtensionException;
 use Nette\SmartObject;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog;
+namespace Mallgroup\Monolog;
 
 use Nette\SmartObject;
 

--- a/src/Processor/PriorityProcessor.php
+++ b/src/Processor/PriorityProcessor.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Processor;
+namespace Mallgroup\Monolog\Processor;
 
 use Monolog\Logger as MonologLogger;
 use Nette\SmartObject;

--- a/src/Processor/TracyExceptionProcessor.php
+++ b/src/Processor/TracyExceptionProcessor.php
@@ -7,9 +7,9 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Processor;
+namespace Mallgroup\Monolog\Processor;
 
-use MG\Monolog\Tracy\BlueScreenRenderer;
+use Mallgroup\Monolog\Tracy\BlueScreenRenderer;
 use Nette\SmartObject;
 
 class TracyExceptionProcessor

--- a/src/Processor/TracyUrlProcessor.php
+++ b/src/Processor/TracyUrlProcessor.php
@@ -7,9 +7,9 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Processor;
+namespace Mallgroup\Monolog\Processor;
 
-use MG\Monolog\Tracy\BlueScreenRenderer;
+use Mallgroup\Monolog\Tracy\BlueScreenRenderer;
 use Nette\SmartObject;
 
 class TracyUrlProcessor

--- a/src/Tracy/BlueScreenRenderer.php
+++ b/src/Tracy/BlueScreenRenderer.php
@@ -7,9 +7,9 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Tracy;
+namespace Mallgroup\Monolog\Tracy;
 
-use MG\Monolog\Exception\NotSupportedException;
+use Mallgroup\Monolog\Exception\NotSupportedException;
 use Nette\SmartObject;
 use Throwable;
 use Tracy\BlueScreen;

--- a/src/Tracy/MonologAdapter.php
+++ b/src/Tracy/MonologAdapter.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the file license.md that was distributed with this source code.
  */
 
-namespace MG\Monolog\Tracy;
+namespace Mallgroup\Monolog\Tracy;
 
 use Monolog\Logger as MonologLogger;
 use Nette\SmartObject;

--- a/stubs/DI/CompilerExtension.stub
+++ b/stubs/DI/CompilerExtension.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace Nette\DI;
+
+use stdClass;
+
+abstract class CompilerExtension {
+	/**
+	 * @var stdClass
+	 */
+	public $config;
+}

--- a/tests/Monolog/BlueScreenRendererTest.phpt
+++ b/tests/Monolog/BlueScreenRendererTest.phpt
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * Test: MG\Monolog\MonologAdapter.
+ * Test: Mallgroup\Monolog\MonologAdapter.
  *
  * @testCase
  */
 
 namespace Tests\Monolog;
 
-use MG\Monolog\Tracy\BlueScreenRenderer;
+use Mallgroup\Monolog\Tracy\BlueScreenRenderer;
 use Tester\Assert;
 use Tracy\BlueScreen;
 
@@ -23,7 +23,7 @@ class BlueScreenRendererTest extends \Tester\TestCase
 
 		Assert::exception(function () use ($renderer) {
 			$renderer->log('message');
-		}, \MG\Monolog\Exception\NotSupportedException::class, 'This class is only for rendering exceptions');
+		}, \Mallgroup\Monolog\Exception\NotSupportedException::class, 'This class is only for rendering exceptions');
 	}
 
 }

--- a/tests/Monolog/ExtensionTest.phpt
+++ b/tests/Monolog/ExtensionTest.phpt
@@ -1,20 +1,19 @@
 <?php
 
 /**
- * Test: MG\Monolog\Extension.
+ * Test: Mallgroup\Monolog\Extension.
  *
  * @testCase
  */
 
 namespace Tests\Monolog;
 
-use MG\Monolog\CustomChannel;
-use MG\Monolog\DI\MonologExtension;
-use MG\Monolog\Logger as MonologLogger;
-use MG\Monolog\Processor\PriorityProcessor;
-use MG\Monolog\Processor\TracyExceptionProcessor;
-use MG\Monolog\Processor\TracyUrlProcessor;
-use MG\Monolog\Tracy\MonologAdapter;
+use Mallgroup\Monolog\CustomChannel;
+use Mallgroup\Monolog\DI\MonologExtension;
+use Mallgroup\Monolog\Logger as MonologLogger;
+use Mallgroup\Monolog\Processor\PriorityProcessor;
+use Mallgroup\Monolog\Processor\TracyExceptionProcessor;
+use Mallgroup\Monolog\Processor\TracyUrlProcessor;
 use Monolog\Handler\BrowserConsoleHandler;
 use Monolog\Handler\ChromePHPHandler;
 use Monolog\Handler\NewRelicHandler;
@@ -63,7 +62,7 @@ class ExtensionTest extends \Tester\TestCase
 		Debugger::$logDirectory = TEMP_DIR;
 
 		$dic = $this->createContainer('default');
-		/** @var \MG\Monolog\Logger $logger */
+		/** @var \Mallgroup\Monolog\Logger $logger */
 		$logger = $dic->getByType(MonologLogger::class);
 
 		Debugger::log('tracy message 1');
@@ -110,12 +109,12 @@ class ExtensionTest extends \Tester\TestCase
 			'[%a%] tracy message 1 {"at":"%a%"} []' . "\n" .
 			'[%a%] Exception: tracy exception message 2 in %a%:%d% {"at":"%a%","exception":"%a%","tracy_filename":"exception-%a%.html","tracy_created":true} []' . "\n" .
 			'[%a%] logger message 1 [] []',
-			file_get_contents(TEMP_DIR . '/info.log')
+			file_get_contents(TEMP_DIR . '/log/info.log')
 		);
 		Assert::match(
 			'[%a%] exception message 1 {"exception":"%a%","tracy_filename":"exception-%a%.html","tracy_created":true} []' . "\n" .
 			'[%a%] exception message 2 {"exception":"%a%","tracy_filename":"exception-%a%.html","tracy_created":true} []',
-			file_get_contents(TEMP_DIR . '/warning.log')
+			file_get_contents(TEMP_DIR . '/log/warning.log')
 		);
 
 		Assert::match(
@@ -123,7 +122,7 @@ class ExtensionTest extends \Tester\TestCase
 			'[%a%] Exception: tracy exception message 1 in %a%:%d% {"at":"%a%","exception":"%a%","tracy_filename":"exception-%a%.html","tracy_created":true} []' . "\n" .
 			'[%a%] logger message 3 [] []' . "\n" .
 			'[%a%] logger message 17 [] []',
-			file_get_contents(TEMP_DIR . '/error.log')
+			file_get_contents(TEMP_DIR . '/log/error.log')
 		);
 
 		Assert::match(
@@ -138,37 +137,37 @@ class ExtensionTest extends \Tester\TestCase
 			'[%a%] ERROR: logger message 18 [] []' . "\n" .
 			'[%a%] CRITICAL: logger message 20 [] []' . "\n" .
 			'[%a%] EMERGENCY: logger message 22 [] []' . "\n",
-			file_get_contents(TEMP_DIR . '/custom.log')
+			file_get_contents(TEMP_DIR . '/log/custom.log')
 		);
 
 		Assert::match(
 			'[%a%] logger message 5 [] []' . "\n",
-			file_get_contents(TEMP_DIR . '/debug.log')
+			file_get_contents(TEMP_DIR . '/log/debug.log')
 		);
 
 		Assert::match(
 			'[%a%] logger message 7 [] []' . "\n",
-			file_get_contents(TEMP_DIR . '/notice.log')
+			file_get_contents(TEMP_DIR . '/log/notice.log')
 		);
 
 		Assert::match(
 			'[%a%] logger message 9 [] []' . "\n" .
 			'[%a%] logger message 19 [] []',
-			file_get_contents(TEMP_DIR . '/critical.log')
+			file_get_contents(TEMP_DIR . '/log/critical.log')
 		);
 
 		Assert::match(
 			'[%a%] logger message 11 [] []' . "\n",
-			file_get_contents(TEMP_DIR . '/alert.log')
+			file_get_contents(TEMP_DIR . '/log/alert.log')
 		);
 
 		Assert::match(
 			'[%a%] logger message 13 [] []' . "\n" .
 			'[%a%] logger message 21 [] []' . "\n",
-			file_get_contents(TEMP_DIR . '/emergency.log')
+			file_get_contents(TEMP_DIR . '/log/emergency.log')
 		);
 
-		Assert::count(4, glob(TEMP_DIR . '/exception-*.html'));
+		Assert::count(4, glob(TEMP_DIR . '/log/exception-*.html'));
 
 		// TEST FOR CUSTOM CHANNEL
 
@@ -219,7 +218,7 @@ class ExtensionTest extends \Tester\TestCase
 			'[%a%] ALERT: custom channel message 18 [] []' . "\n" .
 			'[%a%] EMERGENCY: custom channel message 19 [] []' . "\n" .
 			'[%a%] EMERGENCY: custom channel message 20 [] []' . "\n",
-			file_get_contents(TEMP_DIR . '/test.log')
+			file_get_contents(TEMP_DIR . '/log/test.log')
 		);
 	}
 

--- a/tests/Monolog/FallbackNetteHandlerTest.phpt
+++ b/tests/Monolog/FallbackNetteHandlerTest.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: MG\Monolog\FallbackNetteHandler.
+ * Test: Mallgroup\Monolog\FallbackNetteHandler.
  *
  * @testCase
  */
@@ -9,7 +9,7 @@
 namespace Tests\Monolog;
 
 use DateTime;
-use MG\Monolog\Handler\FallbackNetteHandler;
+use Mallgroup\Monolog\Handler\FallbackNetteHandler;
 use Monolog\Logger as MonologLogger;
 use Tester\Assert;
 

--- a/tests/Monolog/MonologAdapterTest.phpt
+++ b/tests/Monolog/MonologAdapterTest.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: MG\Monolog\MonologAdapter.
+ * Test: Mallgroup\Monolog\MonologAdapter.
  *
  * @testCase
  */
@@ -9,8 +9,8 @@
 namespace Tests\Monolog;
 
 use DateTimeInterface;
-use MG\Monolog\Tracy\BlueScreenRenderer;
-use MG\Monolog\Tracy\MonologAdapter;
+use Mallgroup\Monolog\Tracy\BlueScreenRenderer;
+use Mallgroup\Monolog\Tracy\MonologAdapter;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger as MonologLogger;
 use Tester\Assert;

--- a/tests/Monolog/PriorityProcessorTest.phpt
+++ b/tests/Monolog/PriorityProcessorTest.phpt
@@ -1,14 +1,14 @@
 <?php
 
 /**
- * Test: MG\Monolog\PriorityProcessor.
+ * Test: Mallgroup\Monolog\PriorityProcessor.
  *
  * @testCase
  */
 
 namespace Tests\Monolog;
 
-use MG\Monolog\Processor\PriorityProcessor;
+use Mallgroup\Monolog\Processor\PriorityProcessor;
 use Tester\Assert;
 
 require_once __DIR__ . '/../bootstrap.php';

--- a/tests/Monolog/TracyExceptionProcessorTest.phpt
+++ b/tests/Monolog/TracyExceptionProcessorTest.phpt
@@ -1,15 +1,15 @@
 <?php
 
 /**
- * Test: MG\Monolog\Processor\TracyExceptionProcessor.
+ * Test: Mallgroup\Monolog\Processor\TracyExceptionProcessor.
  *
  * @testCase
  */
 
 namespace Tests\Monolog;
 
-use MG\Monolog\Processor\TracyExceptionProcessor;
-use MG\Monolog\Tracy\BlueScreenRenderer;
+use Mallgroup\Monolog\Processor\TracyExceptionProcessor;
+use Mallgroup\Monolog\Tracy\BlueScreenRenderer;
 use Tester\Assert;
 use Tracy\BlueScreen;
 

--- a/tests/Monolog/TracyUrlProcessorTest.phpt
+++ b/tests/Monolog/TracyUrlProcessorTest.phpt
@@ -1,15 +1,15 @@
 <?php
 
 /**
- * Test: MG\Monolog\Processor\TracyUrlProcessor.
+ * Test: Mallgroup\Monolog\Processor\TracyUrlProcessor.
  *
  * @testCase
  */
 
 namespace Tests\Monolog;
 
-use MG\Monolog\Processor\TracyUrlProcessor;
-use MG\Monolog\Tracy\BlueScreenRenderer;
+use Mallgroup\Monolog\Processor\TracyUrlProcessor;
+use Mallgroup\Monolog\Tracy\BlueScreenRenderer;
 use Tester\Assert;
 use Tracy\BlueScreen;
 

--- a/tests/Monolog/config/default.neon
+++ b/tests/Monolog/config/default.neon
@@ -1,2 +1,3 @@
 monolog:
 	registerFallback: true
+	logDir: %tempDir%/log

--- a/tests/Monolog/config/handlers.neon
+++ b/tests/Monolog/config/handlers.neon
@@ -1,5 +1,6 @@
 monolog:
+	logDir: %tempDir%/log
 	handlers:
-		- Monolog\Handler\BrowserConsoleHandler()
-		- Monolog\Handler\ChromePHPHandler()
-		- Monolog\Handler\NewRelicHandler()
+		- Monolog\Handler\BrowserConsoleHandler
+		- Monolog\Handler\ChromePHPHandler
+		- Monolog\Handler\NewRelicHandler

--- a/tests/Monolog/config/processors.neon
+++ b/tests/Monolog/config/processors.neon
@@ -1,6 +1,7 @@
 monolog:
-	tracyBaseUrl: https://exceptions.kdyby.org
+	logDir: %tempDir%/log
+	tracyBaseUrl: https://exception.mallgroup.com
 	processors:
-		- Monolog\Processor\GitProcessor()
-		- Monolog\Processor\ProcessIdProcessor()
-		- Monolog\Processor\WebProcessor()
+		- Monolog\Processor\GitProcessor
+		- Monolog\Processor\ProcessIdProcessor
+		- Monolog\Processor\WebProcessor


### PR DESCRIPTION


Configuration changes
======

Removed Nette 2.4 compatibility, sorry

Global
-------
hookToTracy was replaced by tracyHook (BC Break)
logDir is not get from Debugger, but expected in config (BC Break)

Configuration - handers
---------------
You can now add Handlers and Processors like this
```
handlers:
    - ConsoleHandler
    - @niceConsole
    newType:
        factory: NewTypeHandler
        setup:
            - setFormatter(@formatter)
```

You cant wrote this (BC break)
```
handlers:
    - ConsoleHandler()
```

It will result in error...

